### PR TITLE
Release/1.3.2

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,6 +6,7 @@ The following versions of `smppjs` are currently supported with security updates
 
 | Version | Supported          |
 | ------- | ------------------ |
+| 1.3.0     | ✅                |
 | 1.2.0     | ✅                |
 | 1.1.0     | ❌                |
 | 1.0.0     | ❌                |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smppjs",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Modern approach to smpp protocol.",
   "main": "lib/index.js",
   "types": "lib",

--- a/src/client.ts
+++ b/src/client.ts
@@ -21,6 +21,10 @@ export default class Client implements IClient {
     private readonly session: Session;
     private _debug: boolean;
     private _enquireLink: { auto: boolean; interval?: number };
+    /**
+     * Uses ReturnType<typeof setTimeout> to automatically infer the correct type to old node versions.
+     */
+    private _enquireLinkTimeout: ReturnType<typeof setTimeout> | undefined;
 
     public get debug(): boolean {
         return this._debug;
@@ -72,6 +76,7 @@ export default class Client implements IClient {
     }
 
     disconnect(): boolean {
+        this.stopEnquireLink();
         return this.session.disconnect();
     }
 
@@ -177,7 +182,7 @@ export default class Client implements IClient {
 
     private autoEnquireLink(interval: number = 20000) {
         const scheduleNext = () => {
-            setTimeout(() => {
+            this._enquireLinkTimeout = setTimeout(() => {
                 if (this.connected) {
                     this.enquireLink();
                     scheduleNext();
@@ -186,5 +191,12 @@ export default class Client implements IClient {
         };
 
         scheduleNext();
+    }
+
+    private stopEnquireLink(): void {
+        if (this._enquireLinkTimeout) {
+            clearTimeout(this._enquireLinkTimeout);
+            this._enquireLinkTimeout = undefined;
+        }
     }
 }

--- a/src/helpers/dtoValidation.ts
+++ b/src/helpers/dtoValidation.ts
@@ -38,7 +38,7 @@ export const dtoValidation = ({
         const maxLength = MAX_LENGTH[fieldName];
 
         if (value && value.toString().length + 1 > maxLength) {
-            throw new Error(`${fieldName} need to be minor than ${maxLength}`);
+            throw new Error(`${fieldName} must be less than ${maxLength}`);
         }
     };
 
@@ -57,10 +57,10 @@ export const dtoValidation = ({
     };
 
     for (let index = 0; index < dtoRecordEntries.length; index += 1) {
-        const dto = dtoRecordEntries[index];
-        const fieldName = dto[0];
-        const value = dto[1].value;
-        const type = dto[1].type;
+        const dtoEntry = dtoRecordEntries[index];
+        const fieldName = dtoEntry[0];
+        const value = dtoEntry[1].value;
+        const type = dtoEntry[1].type;
 
         if (type === 'Array' && value) {
             const subDtoRecordEntries = Object.entries(value as Record<string, DTOCommand>[]);

--- a/src/octets/cstring.ts
+++ b/src/octets/cstring.ts
@@ -21,7 +21,6 @@ class Cstring {
         setLength?: boolean;
         encoding?: Encode;
     }): Buffer {
-        const newBuffer = buffer;
         let valueBuffer: Buffer;
 
         if (typeof value === 'string') {
@@ -35,9 +34,9 @@ class Cstring {
         }
 
         valueBuffer.copy(buffer, offset);
-        newBuffer[offset + valueBuffer.length] = 0;
+        buffer[offset + valueBuffer.length] = 0;
 
-        return newBuffer;
+        return buffer;
     }
 
     /**

--- a/src/session.ts
+++ b/src/session.ts
@@ -88,7 +88,6 @@ export default class Session {
             this.connected = false;
             this.logger.debug(`disconnect - forced - disconnected from smpp server.`);
             this.socket.destroy();
-            throw new Error('Server closed the conn.');
         });
     }
 

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -8,10 +8,9 @@ class Logger {
         },
     ) {}
 
-    debug(message: string, object?: object) {
-        const messageEmit = `${message} - ${object ? JSON.stringify(object) : '{}'}`;
-
+    debug(message: string, object?: object): void {
         if (this.options.debug) {
+            const messageEmit = object ? `${message} - ${JSON.stringify(object)}` : `${message} - {}`;
             this.socket.emit('debug', messageEmit);
         }
     }


### PR DESCRIPTION
## 📝 Description
Release focused on improving use of enquireLink timeout and minor general adjustments for a _tiny..tiny..tinyyy_ performance gain. 

### 🔧 Changes Made
- Client
  - Create stopEnquireLink function to client
  - Set timeout of enquirelink to a variable
  - Clear timeout on disconnect
- Use different name to dto var on dtoValidation.
- Re-use buffer var on cstring write function to gain performance.
- Create var only if debug is true on logger debug to gain performance.
- Remove throw on `initResponseEnd` _**[Possible break change]**_ ⚠️
  - You can continue with the same procedure as before by simply calling the throw in the `.on('end')` method.