### PR TITLE
fix(cstring): skip null terminator for length-prefixed writes

### DIFF
--- a/src/octets/cstring.ts
+++ b/src/octets/cstring.ts
@@ -34,7 +34,10 @@ class Cstring {
         }
 
         valueBuffer.copy(buffer, offset);
-        buffer[offset + valueBuffer.length] = 0;
+
+        if (!setLength) {
+            buffer[offset + valueBuffer.length] = 0;
+        }
 
         return buffer;
     }


### PR DESCRIPTION
Closes #47

## Summary

Fix a bug where Cstring.write() appends a null terminator (0x00) even when setLength=true (length-prefixed mode), causing an extra byte that corrupts PDU field offsets on SMPP v3.4 clients.

## Changes

- Guard null byte append with !setLength condition in src/octets/cstring.ts

## Context

SMPP protocol supports two string encoding modes:
- C-String (null-terminated): value followed by 0x00
- Length-prefixed: length byte followed by value, no null terminator

The original code unconditionally wrote 0x00 after the value, which is correct for C-Strings but invalid for length-prefixed fields. This extra byte shifts all subsequent field offsets by 1, causing v3.4 clients to misparse the PDU.

## Testing

- TypeScript build passes (tsc -p .)
- Verified PDU hex output with v3.4 bind parameters