### PR TITLE
fix(el): defer heartbeat until bind response

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -34,6 +34,10 @@ export default class Client implements IClient {
         return this.session.connected;
     }
 
+    public get bound(): boolean {
+        return this.session.bound;
+    }
+
     /**
      *
      * @param enquireLink Interval is in milliseconds.
@@ -70,8 +74,13 @@ export default class Client implements IClient {
         this.session.connect({ host, port });
 
         if (this._enquireLink.auto && this._enquireLink.interval) {
-            this.enquireLink();
-            this.autoEnquireLink(this._enquireLink.interval);
+            const interval = this._enquireLink.interval;
+            const onBound = (pdu: Pdu) => {
+                if (pdu.command_status === 0) this.autoEnquireLink(interval);
+            };
+            for (const evt of ['bind_transceiver_resp', 'bind_transmitter_resp', 'bind_receiver_resp'] as const) {
+                this.on(evt, onBound);
+            }
         }
     }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -199,7 +199,9 @@ export default class Client implements IClient {
             }, interval);
         };
 
+    if (!this._enquireLinkTimeout) {
         scheduleNext();
+    }
     }
 
     private stopEnquireLink(): void {

--- a/src/session.ts
+++ b/src/session.ts
@@ -30,7 +30,7 @@ import {
     SubmitMultiFunction,
 } from './types';
 
-const bindRespCommands = new Set(['bind_transceiver_resp', 'bind_transmitter_resp', 'bind_receiver_resp']);
+const bindRespCommands = ['bind_transceiver_resp', 'bind_transmitter_resp', 'bind_receiver_resp'];
 
 export default class Session {
     private socket!: Socket | TLSSocket;
@@ -114,7 +114,7 @@ export default class Session {
                     this.socket.emit('pdu', pdu);
                     this.socket.emit(pdu.command, pdu);
 
-                    if (bindRespCommands.has(pdu.command) && pdu.command_status === 0) {
+                    if (bindRespCommands.includes(pdu.command) && pdu.command_status === 0) {
                         this.bound = true;
                     }
                 }

--- a/src/session.ts
+++ b/src/session.ts
@@ -10,7 +10,6 @@ import {
     SubmitSmFunction,
     SubmitSmParams,
     EnquireLinkFunction,
-    EnquireLinkRespFunction,
     BindReceiverParams,
     BindReceiverFunction,
     UnbindFunction,
@@ -114,11 +113,6 @@ export default class Session {
                     this.logger.debug(`${pdu.command} - received`, pdu);
                     this.socket.emit('pdu', pdu);
                     this.socket.emit(pdu.command, pdu);
-
-                    if (pdu.command === 'enquire_link') {
-                        const dto = getDTO<EnquireLinkRespFunction>('enquire_link_resp')({});
-                        this.PDU.call({ command: 'enquire_link_resp', sequenceNumber: pdu.sequence_number, dto });
-                    }
 
                     if (bindRespCommands.has(pdu.command) && pdu.command_status === 0) {
                         this.bound = true;

--- a/src/types/client.ts
+++ b/src/types/client.ts
@@ -34,6 +34,11 @@ export interface IClient {
     disconnect(): boolean;
 
     /**
+     * Whether the session has been successfully bound to the SMSC.
+     */
+    readonly bound: boolean;
+
+    /**
      *
      * @param eventName
      * @param callback

--- a/src/types/pdu.ts
+++ b/src/types/pdu.ts
@@ -47,6 +47,7 @@ export type SendCommandName =
     | 'cancel_sm'
     | 'bind_transceiver'
     | 'enquire_link'
+    | 'enquire_link_resp'
     | 'submit_multi'
     | 'data_sm';
 
@@ -62,7 +63,6 @@ export type ResponseCommandName =
     | 'replace_sm_resp'
     | 'cancel_sm_resp'
     | 'bind_transceiver_resp'
-    | 'enquire_link_resp'
     | 'submit_multi_resp'
     | 'data_sm_resp'
     | 'outbind'

--- a/src/types/pdu.ts
+++ b/src/types/pdu.ts
@@ -47,7 +47,6 @@ export type SendCommandName =
     | 'cancel_sm'
     | 'bind_transceiver'
     | 'enquire_link'
-    | 'enquire_link_resp'
     | 'submit_multi'
     | 'data_sm';
 
@@ -63,6 +62,7 @@ export type ResponseCommandName =
     | 'replace_sm_resp'
     | 'cancel_sm_resp'
     | 'bind_transceiver_resp'
+    | 'enquire_link_resp'
     | 'submit_multi_resp'
     | 'data_sm_resp'
     | 'outbind'


### PR DESCRIPTION
## Summary

Fixes SMPP protocol violation where `enquire_link` was sent before
bind completed, causing SMSC to reject the connection.

## Changes

- Add `_bound` state tracking to Session with getter/setter
- Auto-reply incoming `enquire_link` with correct sequence_number
- Reset bound state on disconnect/end events
- Defer `autoEnquireLink` until `bind_*_resp` with status === 0
- Move `enquire_link_resp` to `SendCommandName`
- Add `bound` public getter to Client and IClient interface

Closes #49