### PR TITLE
Fix/read-correct-utf16be-on-encode

### DIFF
--- a/src/PDU.ts
+++ b/src/PDU.ts
@@ -222,12 +222,16 @@ export default class PDU implements IPDU {
                 if (key === 'short_message' && dataCoding !== undefined) {
                     const encoding = encodesName[dataCoding];
 
-                    params[key] = octets.Cstring.read({
-                        buffer: pduBuffer,
-                        offset,
-                        encoding,
-                        length: smLength,
-                    });
+                    if (encoding === 'ucs2' && smLength !== undefined && smLength > 0) {
+                        params[key] = octets.Cstring.convertFromUtf16be(pduBuffer, offset, smLength);
+                    } else {
+                        params[key] = octets.Cstring.read({
+                            buffer: pduBuffer,
+                            offset,
+                            encoding,
+                            length: smLength,
+                        });
+                    }
 
                     if (smLength) {
                         offset += smLength;

--- a/src/octets/cstring.ts
+++ b/src/octets/cstring.ts
@@ -78,6 +78,22 @@ class Cstring {
     }
 
     /**
+     * Convert from utf16be (Big Endian)
+     */
+    static convertFromUtf16be(buffer: Buffer, offset: number, length: number): string {
+        const raw = buffer.subarray(offset, offset + length);
+
+        const swapped = Buffer.alloc(raw.length);
+
+        for (let i = 0; i < raw.length; i += 2) {
+            swapped[i] = raw[i + 1];
+            swapped[i + 1] = raw[i];
+        }
+
+        return swapped.toString('ucs2', 0, swapped.length);
+    }
+
+    /**
      * Convert to utf16be (Big Endian)
      */
     static convertToUtf16be(value: Buffer | string): Buffer {


### PR DESCRIPTION
## 📝 Description
Fixed to the reading of chars such as Mandarin, Arabic, and others.

### 🔧 Changes Made
-  Create convert to read messages using big-endian `(utf16be)`
    -  Add convert function to read ucs2 and convert received messages.