### PR TITLE
Feat/add-enquirelink-after-conn-option

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -20,7 +20,7 @@ import type { DTOPayloadMap } from './dtos';
 export default class Client implements IClient {
     private readonly session: Session;
     private _debug: boolean;
-    private _enquireLink: { auto: boolean; interval?: number };
+    private _enquireLink: { auto: boolean; when?: 'connect' | 'bind'; interval?: number };
     /**
      * Uses ReturnType<typeof setTimeout> to automatically infer the correct type to old node versions.
      */
@@ -57,7 +57,7 @@ export default class Client implements IClient {
         /**
          * Default interval 20000
          */
-        enquireLink: { auto: boolean; interval?: number };
+        enquireLink: { auto: boolean; when?: 'connect' | 'bind'; interval?: number };
         secure: { tls?: boolean; unsafeBuffer?: boolean; secureOptions?: SecureContextOptions };
         timeout?: number;
         debug?: boolean;
@@ -65,6 +65,7 @@ export default class Client implements IClient {
         this._debug = debug;
         this._enquireLink = enquireLink;
         this._enquireLink.interval = this._enquireLink.interval || 20000;
+        this._enquireLink.when = this._enquireLink.when || 'bind';
 
         this.session = new Session(interfaceVersion, this.debug, timeout, secure);
     }
@@ -75,11 +76,18 @@ export default class Client implements IClient {
 
         if (this._enquireLink.auto && this._enquireLink.interval) {
             const interval = this._enquireLink.interval;
-            const onBound = (pdu: Pdu) => {
-                if (pdu.command_status === 0) this.autoEnquireLink(interval);
-            };
-            for (const evt of ['bind_transceiver_resp', 'bind_transmitter_resp', 'bind_receiver_resp'] as const) {
-                this.on(evt, onBound);
+
+            if (this._enquireLink.when === 'connect') {
+                this.enquireLink();
+                this.autoEnquireLink(interval);
+            } else {
+                const onBound = (pdu: Pdu) => {
+                    if (pdu.command_status === 0) this.autoEnquireLink(interval);
+                };
+
+                for (const evt of ['bind_transceiver_resp', 'bind_transmitter_resp', 'bind_receiver_resp'] as const) {
+                    this.on(evt, onBound);
+                }
             }
         }
     }
@@ -199,9 +207,9 @@ export default class Client implements IClient {
             }, interval);
         };
 
-    if (!this._enquireLinkTimeout) {
-        scheduleNext();
-    }
+        if (!this._enquireLinkTimeout) {
+            scheduleNext();
+        }
     }
 
     private stopEnquireLink(): void {

--- a/src/client.ts
+++ b/src/client.ts
@@ -56,6 +56,8 @@ export default class Client implements IClient {
         interfaceVersion: InterfaceVersion;
         /**
          * Default interval 20000
+         *
+         * When use 'bind' by default, the enquire link will be sent after the bind is successful.
          */
         enquireLink: { auto: boolean; when?: 'connect' | 'bind'; interval?: number };
         secure: { tls?: boolean; unsafeBuffer?: boolean; secureOptions?: SecureContextOptions };


### PR DESCRIPTION
## 📝 Description
Added option to choose when autoEnquireLink will start.

### 🔧 Changes Made
- Add `when` option to client, on `enquireLink` object.
  - `connect`: Instant connection after connecting to the server.
  - `bind`: Connection after a successful binding.