### PR TITLE
Release/1.3.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smppjs",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "Modern approach to smpp protocol.",
   "main": "lib/index.js",
   "types": "lib",

--- a/src/PDU.ts
+++ b/src/PDU.ts
@@ -222,12 +222,16 @@ export default class PDU implements IPDU {
                 if (key === 'short_message' && dataCoding !== undefined) {
                     const encoding = encodesName[dataCoding];
 
-                    params[key] = octets.Cstring.read({
-                        buffer: pduBuffer,
-                        offset,
-                        encoding,
-                        length: smLength,
-                    });
+                    if (encoding === 'ucs2' && smLength !== undefined && smLength > 0) {
+                        params[key] = octets.Cstring.convertFromUtf16be(pduBuffer, offset, smLength);
+                    } else {
+                        params[key] = octets.Cstring.read({
+                            buffer: pduBuffer,
+                            offset,
+                            encoding,
+                            length: smLength,
+                        });
+                    }
 
                     if (smLength) {
                         offset += smLength;

--- a/src/client.ts
+++ b/src/client.ts
@@ -34,6 +34,10 @@ export default class Client implements IClient {
         return this.session.connected;
     }
 
+    public get bound(): boolean {
+        return this.session.bound;
+    }
+
     /**
      *
      * @param enquireLink Interval is in milliseconds.
@@ -70,8 +74,13 @@ export default class Client implements IClient {
         this.session.connect({ host, port });
 
         if (this._enquireLink.auto && this._enquireLink.interval) {
-            this.enquireLink();
-            this.autoEnquireLink(this._enquireLink.interval);
+            const interval = this._enquireLink.interval;
+            const onBound = (pdu: Pdu) => {
+                if (pdu.command_status === 0) this.autoEnquireLink(interval);
+            };
+            for (const evt of ['bind_transceiver_resp', 'bind_transmitter_resp', 'bind_receiver_resp'] as const) {
+                this.on(evt, onBound);
+            }
         }
     }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -20,7 +20,7 @@ import type { DTOPayloadMap } from './dtos';
 export default class Client implements IClient {
     private readonly session: Session;
     private _debug: boolean;
-    private _enquireLink: { auto: boolean; interval?: number };
+    private _enquireLink: { auto: boolean; when?: 'connect' | 'bind'; interval?: number };
     /**
      * Uses ReturnType<typeof setTimeout> to automatically infer the correct type to old node versions.
      */
@@ -57,7 +57,7 @@ export default class Client implements IClient {
         /**
          * Default interval 20000
          */
-        enquireLink: { auto: boolean; interval?: number };
+        enquireLink: { auto: boolean; when?: 'connect' | 'bind'; interval?: number };
         secure: { tls?: boolean; unsafeBuffer?: boolean; secureOptions?: SecureContextOptions };
         timeout?: number;
         debug?: boolean;
@@ -65,6 +65,7 @@ export default class Client implements IClient {
         this._debug = debug;
         this._enquireLink = enquireLink;
         this._enquireLink.interval = this._enquireLink.interval || 20000;
+        this._enquireLink.when = this._enquireLink.when || 'bind';
 
         this.session = new Session(interfaceVersion, this.debug, timeout, secure);
     }
@@ -75,11 +76,18 @@ export default class Client implements IClient {
 
         if (this._enquireLink.auto && this._enquireLink.interval) {
             const interval = this._enquireLink.interval;
-            const onBound = (pdu: Pdu) => {
-                if (pdu.command_status === 0) this.autoEnquireLink(interval);
-            };
-            for (const evt of ['bind_transceiver_resp', 'bind_transmitter_resp', 'bind_receiver_resp'] as const) {
-                this.on(evt, onBound);
+
+            if (this._enquireLink.when === 'connect') {
+                this.enquireLink();
+                this.autoEnquireLink(interval);
+            } else {
+                const onBound = (pdu: Pdu) => {
+                    if (pdu.command_status === 0) this.autoEnquireLink(interval);
+                };
+
+                for (const evt of ['bind_transceiver_resp', 'bind_transmitter_resp', 'bind_receiver_resp'] as const) {
+                    this.on(evt, onBound);
+                }
             }
         }
     }
@@ -199,9 +207,9 @@ export default class Client implements IClient {
             }, interval);
         };
 
-    if (!this._enquireLinkTimeout) {
-        scheduleNext();
-    }
+        if (!this._enquireLinkTimeout) {
+            scheduleNext();
+        }
     }
 
     private stopEnquireLink(): void {

--- a/src/client.ts
+++ b/src/client.ts
@@ -199,7 +199,9 @@ export default class Client implements IClient {
             }, interval);
         };
 
+    if (!this._enquireLinkTimeout) {
         scheduleNext();
+    }
     }
 
     private stopEnquireLink(): void {

--- a/src/client.ts
+++ b/src/client.ts
@@ -56,6 +56,8 @@ export default class Client implements IClient {
         interfaceVersion: InterfaceVersion;
         /**
          * Default interval 20000
+         *
+         * When use 'bind' by default, the enquire link will be sent after the bind is successful.
          */
         enquireLink: { auto: boolean; when?: 'connect' | 'bind'; interval?: number };
         secure: { tls?: boolean; unsafeBuffer?: boolean; secureOptions?: SecureContextOptions };

--- a/src/octets/cstring.ts
+++ b/src/octets/cstring.ts
@@ -34,7 +34,10 @@ class Cstring {
         }
 
         valueBuffer.copy(buffer, offset);
-        buffer[offset + valueBuffer.length] = 0;
+
+        if (!setLength) {
+            buffer[offset + valueBuffer.length] = 0;
+        }
 
         return buffer;
     }

--- a/src/octets/cstring.ts
+++ b/src/octets/cstring.ts
@@ -78,6 +78,22 @@ class Cstring {
     }
 
     /**
+     * Convert from utf16be (Big Endian)
+     */
+    static convertFromUtf16be(buffer: Buffer, offset: number, length: number): string {
+        const raw = buffer.subarray(offset, offset + length);
+
+        const swapped = Buffer.alloc(raw.length);
+
+        for (let i = 0; i < raw.length; i += 2) {
+            swapped[i] = raw[i + 1];
+            swapped[i + 1] = raw[i];
+        }
+
+        return swapped.toString('ucs2', 0, swapped.length);
+    }
+
+    /**
      * Convert to utf16be (Big Endian)
      */
     static convertToUtf16be(value: Buffer | string): Buffer {

--- a/src/session.ts
+++ b/src/session.ts
@@ -30,7 +30,7 @@ import {
     SubmitMultiFunction,
 } from './types';
 
-const bindRespCommands = new Set(['bind_transceiver_resp', 'bind_transmitter_resp', 'bind_receiver_resp']);
+const bindRespCommands = ['bind_transceiver_resp', 'bind_transmitter_resp', 'bind_receiver_resp'];
 
 export default class Session {
     private socket!: Socket | TLSSocket;
@@ -114,7 +114,7 @@ export default class Session {
                     this.socket.emit('pdu', pdu);
                     this.socket.emit(pdu.command, pdu);
 
-                    if (bindRespCommands.has(pdu.command) && pdu.command_status === 0) {
+                    if (bindRespCommands.includes(pdu.command) && pdu.command_status === 0) {
                         this.bound = true;
                     }
                 }

--- a/src/session.ts
+++ b/src/session.ts
@@ -10,7 +10,6 @@ import {
     SubmitSmFunction,
     SubmitSmParams,
     EnquireLinkFunction,
-    EnquireLinkRespFunction,
     BindReceiverParams,
     BindReceiverFunction,
     UnbindFunction,
@@ -114,11 +113,6 @@ export default class Session {
                     this.logger.debug(`${pdu.command} - received`, pdu);
                     this.socket.emit('pdu', pdu);
                     this.socket.emit(pdu.command, pdu);
-
-                    if (pdu.command === 'enquire_link') {
-                        const dto = getDTO<EnquireLinkRespFunction>('enquire_link_resp')({});
-                        this.PDU.call({ command: 'enquire_link_resp', sequenceNumber: pdu.sequence_number, dto });
-                    }
 
                     if (bindRespCommands.has(pdu.command) && pdu.command_status === 0) {
                         this.bound = true;

--- a/src/types/client.ts
+++ b/src/types/client.ts
@@ -34,6 +34,11 @@ export interface IClient {
     disconnect(): boolean;
 
     /**
+     * Whether the session has been successfully bound to the SMSC.
+     */
+    readonly bound: boolean;
+
+    /**
      *
      * @param eventName
      * @param callback

--- a/src/types/pdu.ts
+++ b/src/types/pdu.ts
@@ -47,6 +47,7 @@ export type SendCommandName =
     | 'cancel_sm'
     | 'bind_transceiver'
     | 'enquire_link'
+    | 'enquire_link_resp'
     | 'submit_multi'
     | 'data_sm';
 
@@ -62,7 +63,6 @@ export type ResponseCommandName =
     | 'replace_sm_resp'
     | 'cancel_sm_resp'
     | 'bind_transceiver_resp'
-    | 'enquire_link_resp'
     | 'submit_multi_resp'
     | 'data_sm_resp'
     | 'outbind'

--- a/src/types/pdu.ts
+++ b/src/types/pdu.ts
@@ -47,7 +47,6 @@ export type SendCommandName =
     | 'cancel_sm'
     | 'bind_transceiver'
     | 'enquire_link'
-    | 'enquire_link_resp'
     | 'submit_multi'
     | 'data_sm';
 
@@ -63,6 +62,7 @@ export type ResponseCommandName =
     | 'replace_sm_resp'
     | 'cancel_sm_resp'
     | 'bind_transceiver_resp'
+    | 'enquire_link_resp'
     | 'submit_multi_resp'
     | 'data_sm_resp'
     | 'outbind'


### PR DESCRIPTION
## 📝 Description
This release focuses on important fixes for client-server connections, as well as correcting the handling of message reception for languages ​​such as Mandarin, Arabic, and others.

### 🔧 Changes Made
- Create convert to read messages using big-endian (utf16be)
  - Add convert function to read ucs2 and convert received messages.
- Add `when` option to client, on `enquireLink` object.
  - `connect`: Instant connection after connecting to the server.
  - `bind`: Connection after a successful binding. 
    - Selected by default  _**⚠️ [Possible break change] ⚠️**_
- Correctly writing the length when received in the `cstring`
  - Others continue inserting `0x00`