### PR TITLE
feat/parse-deliversm-udh-concat-metadata

### DIFF
--- a/src/PDU.ts
+++ b/src/PDU.ts
@@ -3,16 +3,9 @@ import { getDTO } from './dtos/index';
 import { octets } from './octets';
 import { CommandStatus, CommandStatusInfo, commandsId, commandsName, optionalParams, encodesName } from './constains';
 import { DTO, DTOFunction, Encode, IPDU, Pdu, SendCommandName, OptionalParamKey, DTOCommand } from './types';
+import { parseConcatenatedUdh } from './utils/udh.js';
 
 const HEADER_COMMAND_LENGTH = 16;
-
-interface ParsedUdhConcat {
-    udhLength: number;
-    concatIei: number;
-    referenceNumber: number;
-    totalParts: number;
-    partNumber: number;
-}
 
 export default class PDU implements IPDU {
     constructor(
@@ -238,7 +231,7 @@ export default class PDU implements IPDU {
 
                     const hasUdhi = esmClass !== undefined && (esmClass & 0x40) === 0x40;
                     const parsedUdh = hasUdhi
-                        ? this.parseConcatenatedUdh(shortMessageRaw)
+                        ? parseConcatenatedUdh(shortMessageRaw)
                         : null;
 
                     let contentOffset = 0;
@@ -316,55 +309,6 @@ export default class PDU implements IPDU {
         }
 
         return { params, offset };
-    }
-
-    private parseConcatenatedUdh(shortMessageRaw: Buffer): ParsedUdhConcat | null {
-        if (shortMessageRaw.length < 1) {
-            return null;
-        }
-
-        const udhLength = shortMessageRaw[0] + 1;
-
-        if (udhLength <= 1 || udhLength > shortMessageRaw.length) {
-            return null;
-        }
-
-        let offset = 1;
-
-        while (offset + 1 < udhLength) {
-            const iei = shortMessageRaw[offset];
-            const iedl = shortMessageRaw[offset + 1];
-            const ieDataStart = offset + 2;
-            const ieDataEnd = ieDataStart + iedl;
-
-            if (ieDataEnd > udhLength) {
-                return null;
-            }
-
-            if (iei === 0x00 && iedl === 3) {
-                return {
-                    udhLength,
-                    concatIei: iei,
-                    referenceNumber: shortMessageRaw[ieDataStart],
-                    totalParts: shortMessageRaw[ieDataStart + 1],
-                    partNumber: shortMessageRaw[ieDataStart + 2],
-                };
-            }
-
-            if (iei === 0x08 && iedl === 4) {
-                return {
-                    udhLength,
-                    concatIei: iei,
-                    referenceNumber: shortMessageRaw.readUInt16BE(ieDataStart),
-                    totalParts: shortMessageRaw[ieDataStart + 2],
-                    partNumber: shortMessageRaw[ieDataStart + 3],
-                };
-            }
-
-            offset = ieDataEnd;
-        }
-
-        return null;
     }
 
     private readTlvsPdu({

--- a/src/PDU.ts
+++ b/src/PDU.ts
@@ -6,6 +6,14 @@ import { DTO, DTOFunction, Encode, IPDU, Pdu, SendCommandName, OptionalParamKey,
 
 const HEADER_COMMAND_LENGTH = 16;
 
+interface ParsedUdhConcat {
+    udhLength: number;
+    concatIei: number;
+    referenceNumber: number;
+    totalParts: number;
+    partNumber: number;
+}
+
 export default class PDU implements IPDU {
     constructor(
         private socket: Socket,
@@ -211,6 +219,7 @@ export default class PDU implements IPDU {
 
         let dataCoding: number | undefined;
         let smLength: number | undefined;
+        let esmClass: number | undefined;
         let noUnsuccess: number | undefined;
 
         for (const key in pduParams) {
@@ -220,22 +229,39 @@ export default class PDU implements IPDU {
 
             if (type === 'Cstring') {
                 if (key === 'short_message' && dataCoding !== undefined) {
-                    const encoding = encodesName[dataCoding];
+                    const encoding = encodesName[dataCoding] || 'ascii';
+                    const shortMessageLength = smLength || 0;
 
-                    if (encoding === 'ucs2' && smLength !== undefined && smLength > 0) {
-                        params[key] = octets.Cstring.convertFromUtf16be(pduBuffer, offset, smLength);
+                    const shortMessageRaw = shortMessageLength > 0
+                        ? pduBuffer.subarray(offset, offset + shortMessageLength)
+                        : Buffer.alloc(0);
+
+                    const hasUdhi = esmClass !== undefined && (esmClass & 0x40) === 0x40;
+                    const parsedUdh = hasUdhi
+                        ? this.parseConcatenatedUdh(shortMessageRaw)
+                        : null;
+
+                    let contentOffset = 0;
+
+                    if (parsedUdh) {
+                        contentOffset = parsedUdh.udhLength;
+                        params['has_udh'] = 1;
+                        params['udh_length'] = parsedUdh.udhLength;
+                        params['udh_concat_iei'] = parsedUdh.concatIei;
+                        params['udh_concat_ref'] = parsedUdh.referenceNumber;
+                        params['udh_concat_total'] = parsedUdh.totalParts;
+                        params['udh_concat_seq'] = parsedUdh.partNumber;
+                    }
+
+                    const payload = shortMessageRaw.subarray(contentOffset);
+
+                    if (encoding === 'ucs2') {
+                        params[key] = octets.Cstring.convertFromUtf16be(payload, 0, payload.length);
                     } else {
-                        params[key] = octets.Cstring.read({
-                            buffer: pduBuffer,
-                            offset,
-                            encoding,
-                            length: smLength,
-                        });
+                        params[key] = payload.toString(encoding);
                     }
 
-                    if (smLength) {
-                        offset += smLength;
-                    }
+                    offset += shortMessageLength;
                 } else {
                     params[key] = octets.Cstring.read({ buffer: pduBuffer, offset });
                     offset += octets.Cstring.size((params[key] as string) || (value as string));
@@ -245,6 +271,10 @@ export default class PDU implements IPDU {
             if (type === 'Int8') {
                 params[key] = octets.Int8.read({ buffer: pduBuffer, offset });
                 offset += octets.Int8.size();
+
+                if (key === 'esm_class') {
+                    esmClass = params[key] as number;
+                }
 
                 if (key === 'data_coding') {
                     dataCoding = params[key] as number;
@@ -286,6 +316,55 @@ export default class PDU implements IPDU {
         }
 
         return { params, offset };
+    }
+
+    private parseConcatenatedUdh(shortMessageRaw: Buffer): ParsedUdhConcat | null {
+        if (shortMessageRaw.length < 1) {
+            return null;
+        }
+
+        const udhLength = shortMessageRaw[0] + 1;
+
+        if (udhLength <= 1 || udhLength > shortMessageRaw.length) {
+            return null;
+        }
+
+        let offset = 1;
+
+        while (offset + 1 < udhLength) {
+            const iei = shortMessageRaw[offset];
+            const iedl = shortMessageRaw[offset + 1];
+            const ieDataStart = offset + 2;
+            const ieDataEnd = ieDataStart + iedl;
+
+            if (ieDataEnd > udhLength) {
+                return null;
+            }
+
+            if (iei === 0x00 && iedl === 3) {
+                return {
+                    udhLength,
+                    concatIei: iei,
+                    referenceNumber: shortMessageRaw[ieDataStart],
+                    totalParts: shortMessageRaw[ieDataStart + 1],
+                    partNumber: shortMessageRaw[ieDataStart + 2],
+                };
+            }
+
+            if (iei === 0x08 && iedl === 4) {
+                return {
+                    udhLength,
+                    concatIei: iei,
+                    referenceNumber: shortMessageRaw.readUInt16BE(ieDataStart),
+                    totalParts: shortMessageRaw[ieDataStart + 2],
+                    partNumber: shortMessageRaw[ieDataStart + 3],
+                };
+            }
+
+            offset = ieDataEnd;
+        }
+
+        return null;
     }
 
     private readTlvsPdu({

--- a/src/types/dto/deliver_sm.ts
+++ b/src/types/dto/deliver_sm.ts
@@ -48,6 +48,18 @@ export type DeliverSmParams = {
         message: string;
         encoding?: Encode;
     };
+    /** Indicates if UDH (User Data Header) is present (1 = present, 0 = absent) */
+    has_udh?: number;
+    /** Length of the UDH in bytes, including the UDHL field itself */
+    udh_length?: number;
+    /** Information Element Identifier for concatenated messages (0x00 for 8-bit ref, 0x08 for 16-bit ref) */
+    udh_concat_iei?: number;
+    /** Reference number identifying the concatenated message set */
+    udh_concat_ref?: number;
+    /** Total number of parts in the concatenated message */
+    udh_concat_total?: number;
+    /** Sequence number of this part in the concatenated message (1-based) */
+    udh_concat_seq?: number;
 };
 
 export interface DeliverSmFunction extends DTOFunction<DeliverSmParams, DeliverSm> {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,1 +1,2 @@
 export * from './logger';
+export * from './udh.js';

--- a/src/utils/udh.ts
+++ b/src/utils/udh.ts
@@ -1,0 +1,65 @@
+/**
+ * Parsed UDH concatenation metadata
+ */
+export interface ParsedUdhConcat {
+    udhLength: number;
+    concatIei: number;
+    referenceNumber: number;
+    totalParts: number;
+    partNumber: number;
+}
+
+/**
+ * Parse concatenated message UDH from short_message buffer
+ * Supports IEI 0x00 (8-bit ref) and 0x08 (16-bit ref)
+ * @param shortMessageRaw - Raw short_message buffer containing UDH
+ * @returns Parsed UDH metadata or null if no concatenation IE found
+ */
+export function parseConcatenatedUdh(shortMessageRaw: Buffer): ParsedUdhConcat | null {
+    if (shortMessageRaw.length < 1) {
+        return null;
+    }
+
+    const udhLength = shortMessageRaw[0] + 1;
+
+    if (udhLength <= 1 || udhLength > shortMessageRaw.length) {
+        return null;
+    }
+
+    let offset = 1;
+
+    while (offset + 1 < udhLength) {
+        const iei = shortMessageRaw[offset];
+        const iedl = shortMessageRaw[offset + 1];
+        const ieDataStart = offset + 2;
+        const ieDataEnd = ieDataStart + iedl;
+
+        if (ieDataEnd > udhLength) {
+            return null;
+        }
+
+        if (iei === 0x00 && iedl === 3) {
+            return {
+                udhLength,
+                concatIei: iei,
+                referenceNumber: shortMessageRaw[ieDataStart],
+                totalParts: shortMessageRaw[ieDataStart + 1],
+                partNumber: shortMessageRaw[ieDataStart + 2],
+            };
+        }
+
+        if (iei === 0x08 && iedl === 4) {
+            return {
+                udhLength,
+                concatIei: iei,
+                referenceNumber: shortMessageRaw.readUInt16BE(ieDataStart),
+                totalParts: shortMessageRaw[ieDataStart + 2],
+                partNumber: shortMessageRaw[ieDataStart + 3],
+            };
+        }
+
+        offset = ieDataEnd;
+    }
+
+    return null;
+}


### PR DESCRIPTION
## Summary
- parse UDHI in inbound `deliver_sm` when `esm_class & 0x40` is set
- support concatenation IEI `0x00` (8-bit ref) and `0x08` (16-bit ref)
- replace `short_message` with payload text after stripping UDH bytes
- append parsed UDH fields to params: `has_udh`, `udh_length`, `udh_concat_iei`, `udh_concat_ref`, `udh_concat_total`, `udh_concat_seq`
- keep safe fallback for malformed UDH (no crash, no invalid concat fields)

## Why
Applications currently need to re-parse UDH from `short_message` even after core decoding. This change centralizes protocol-level UDH concat parsing in smppjs and reduces duplicate app-side logic.

## Related issue
Closes #56

## Validation
- `npm run prod:build` passes
- `npm run lint` shows existing warnings in unrelated files:
  - `src/dtos/replace_sm.ts`
  - `src/dtos/submit_multi.ts`
  - `src/dtos/submit_sm.ts`

## Test plan
- [x] build TypeScript project
- [ ] verify inbound `deliver_sm` with UDHI + IEI 0x00
- [ ] verify inbound `deliver_sm` with UDHI + IEI 0x08
- [ ] verify malformed UDH falls back safely