### PR TITLE
fix session parsing for multi-PDU readable chunks

### DIFF
--- a/src/session.ts
+++ b/src/session.ts
@@ -105,21 +105,38 @@ export default class Session {
 
     initResponseRead(): void {
         this.socket.on('readable', () => {
-            try {
-                const data = this.socket.read();
+            let data: Buffer | null;
 
-                if (data) {
-                    const pdu = this.PDU.readPdu(data);
-                    this.logger.debug(`${pdu.command} - received`, pdu);
-                    this.socket.emit('pdu', pdu);
-                    this.socket.emit(pdu.command, pdu);
+            while ((data = this.socket.read()) !== null) {
+                try {
+                    let offset = 0;
 
-                    if (bindRespCommands.includes(pdu.command) && pdu.command_status === 0) {
-                        this.bound = true;
+                    while (offset < data.length) {
+                        if (data.length - offset < 4) {
+                            break;
+                        }
+
+                        const pduLength = data.readUInt32BE(offset);
+
+                        if (data.length - offset < pduLength) {
+                            break;
+                        }
+
+                        const pduBuffer = data.subarray(offset, offset + pduLength);
+                        const pdu = this.PDU.readPdu(pduBuffer);
+                        this.logger.debug(`${pdu.command} - received`, pdu);
+                        this.socket.emit('pdu', pdu);
+                        this.socket.emit(pdu.command, pdu);
+
+                        if (bindRespCommands.includes(pdu.command) && pdu.command_status === 0) {
+                            this.bound = true;
+                        }
+
+                        offset += pduLength;
                     }
+                } catch (error) {
+                    this.socket.emit('error', error);
                 }
-            } catch (error) {
-                this.socket.emit('error', error);
             }
         });
     }


### PR DESCRIPTION
## Summary
- parse all PDUs in one readable buffer using `command_length` framing
- keep existing event emission and bind state behavior per parsed PDU
- fix dropped trailing PDUs when one TCP read contains multiple SMPP frames

## Root cause
`Session.initResponseRead()` previously parsed only one PDU per `socket.read()` result.
When a readable chunk contained multiple SMPP PDUs, only the first was processed.

## Note about prior observation
I actually noticed this issue earlier around PR #48 (`fix/cstring-null-terminator`),
but forgot to report/follow up at that time. Sorry for the delayed follow-up.

## Wireshark capture details
The following capture shows a reproducible multi-PDU-in-one-read case.

### Frame 619
- TCP Len: 206
- SMPP: `deliver_sm`, Seq=4, Len=206

### Frame 621
- TCP Len: 350
- SMPP PDU 1: `deliver_sm`, Seq=5, Len=206
- SMPP PDU 2: `deliver_sm`, Seq=6, Len=144

This confirms a single TCP payload can carry more than one SMPP PDU.

<details>
<summary>Provided Wireshark excerpt</summary>

```text
Frame 619: Packet, 258 bytes on wire (2064 bits), 258 bytes captured (2064 bits) on interface utun4, id 0
Raw packet data
Internet Protocol Version 4, Src: 10.0.0.7, Dst: 198.18.0.1
Transmission Control Protocol, Src Port: 2775, Dst Port: 56740, Seq: 55, Ack: 95, Len: 206
Short Message Peer to Peer, Command: Deliver_sm, Seq: 4, Len: 206
...

Frame 621: Packet, 402 bytes on wire (3216 bits), 402 bytes captured (3216 bits) on interface utun4, id 0
Raw packet data
Internet Protocol Version 4, Src: 10.0.0.7, Dst: 198.18.0.1
Transmission Control Protocol, Src Port: 2775, Dst Port: 56740, Seq: 261, Ack: 95, Len: 350
Short Message Peer to Peer, Command: Deliver_sm, Seq: 5, Len: 206
...
Short Message Peer to Peer, Command: Deliver_sm, Seq: 6, Len: 144
...
```

</details>

**Original Wireshark data packet: [multi-pdu-read.pcapng.zip](https://github.com/user-attachments/files/25735432/multi-pdu-read.pcapng.zip)**


## Test plan
- [x] npm run prod:build
- [x] npm run lint (existing warnings only)
- [ ] validate with an SMSC payload containing 2+ `deliver_sm` PDUs in one read